### PR TITLE
fix(frontend): disable 103 early hints

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -80,7 +80,7 @@ async function startServer() {
         next()
       } else {
         const { body, statusCode, headers, earlyHints } = httpResponse
-        if (res.writeEarlyHints)
+        if (process.env.EARLY_HINTS && res.writeEarlyHints)
           res.writeEarlyHints({ link: earlyHints.map((e) => e.earlyHintLink) })
         headers.forEach(([name, value]) => res.setHeader(name, value))
         res.status(statusCode)


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

This PR disables 103 Early Hints by default unless the server is started with `export EARLY_HINTS=true`.

This is in light of nginx not able to properly support this response. See https://vike.dev/nginx

This speeds up page delivery for pages not prerendered (e.g. 404 pages)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
