### PR TITLE
fix(frontend): allow use of SCSS-@-directives in .vue files

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,4 +6,4 @@
       "stylelint-config-recommended-vue/scss",
       "stylelint-config-recess-order"
     ]
-  }
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,9 +1,9 @@
 {
     "extends": [
-        "stylelint-config-standard",
-        "stylelint-config-standard-scss",
-        "stylelint-config-recommended-vue",
-        "stylelint-config-recess-order",
-        "stylelint-config-css-modules"
+      "stylelint-config-standard",
+      "stylelint-config-standard-scss",
+      "stylelint-config-css-modules",
+      "stylelint-config-recommended-vue/scss",
+      "stylelint-config-recess-order"
     ]
-}
+  }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Change order of extends in .stylelintrc.json and use correct preset for Vue with SCSS.

### Issues
- None

Enables successful linting for https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/7128
